### PR TITLE
Variable rename

### DIFF
--- a/trawler.ps1
+++ b/trawler.ps1
@@ -59,7 +59,7 @@ param
 		Mandatory = $false,
 		HelpMessage = 'Suppress Detection Output to Console')]
 	[switch]
-	$hide,
+	$Quiet,
 	[Parameter(
 		Mandatory = $false,
 		HelpMessage = 'The fully-qualified file-path where persistence snapshot output should be stored as a CSV, defaults to $PSScriptRoot\snapshot.csv')]
@@ -167,11 +167,6 @@ param
 
 # TODO - Refactor below into setup function
 # Script Level Variable Setup
-if ($hide.IsPresent){
-    $hide_console_output = $true
-} else {
-    $hide_console_output = $false
-}
 
 if ($PSBoundParameters.ContainsKey('loadsnapshot')){
     $loadsnapshotdata = $true
@@ -190,7 +185,8 @@ $detection_list = New-Object -TypeName "System.Collections.ArrayList"
 
 function Get-ValidOutPath {
 	param (
-		[string]$path
+		[string]
+		$path
 	)
 
 	if (Test-Path -Path $path -PathType Container)
@@ -206,7 +202,7 @@ function ValidatePaths {
     try {
         $script:outpath = Get-ValidOutPath -path $outpath
         Write-Message "Detection Output Path: $outpath"
-        [io.file]::OpenWrite($outpath).close()
+        [System.IO.File]::OpenWrite($outpath).Close()
         $script:output_writable = $true
     }
     catch {
@@ -218,7 +214,7 @@ function ValidatePaths {
         try {
             $script:snapshotpath = Get-ValidOutPath -path $snapshotpath
             Write-Message "Snapshot Output Path: $snapshotpath"
-            [io.file]::OpenWrite($snapshotpath).close()
+            [System.IO.File]::OpenWrite($snapshotpath).close()
             Clear-Content $snapshotpath
             $script:snapshotpath_writable = $true
         }
@@ -227,7 +223,6 @@ function ValidatePaths {
             $script:snapshotpath_writable = $false
         }
     }
-
 }
 
 
@@ -16384,7 +16379,7 @@ function Write-Detection($det) {
 		Default { $fg_color = "Yellow" }
 	}
 
-	if (-not($hide_console_output)) {
+	if (-not($Quiet)) {
 		Write-Host "[!] Detection: $($det.Name) - Risk: $($det.Risk)" -ForegroundColor $fg_color
 		Write-Host "[%] $($det.Meta)" -ForegroundColor White
 	}

--- a/trawler.ps1
+++ b/trawler.ps1
@@ -214,7 +214,7 @@ function ValidatePaths {
         try {
             $script:snapshotpath = Get-ValidOutPath -path $snapshotpath
             Write-Message "Snapshot Output Path: $snapshotpath"
-            [System.IO.File]::OpenWrite($snapshotpath).close()
+            [System.IO.File]::OpenWrite($snapshotpath).Close()
             Clear-Content $snapshotpath
             $script:snapshotpath_writable = $true
         }


### PR DESCRIPTION
Renamed the $hide script level var to $Quiet. This is more in line with PS Standards